### PR TITLE
Set NSBluetoothAlwaysUsageDescription as required for iOS 13

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,5 +10,8 @@
     <config-file target="*-Info.plist" parent="NSBluetoothPeripheralUsageDescription">
       <string>$TEXT</string>
     </config-file>
+    <config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
+      <string>$TEXT</string>
+    </config-file>
   </platform>
 </plugin>


### PR DESCRIPTION
For details: https://developer.apple.com/documentation/bundleresources/information_property_list/nsbluetoothalwaysusagedescription?language=objc